### PR TITLE
Updated Digit Parser

### DIFF
--- a/jquery.tablesorter.js
+++ b/jquery.tablesorter.js
@@ -900,7 +900,7 @@
             var c = table.config;
             return $.tablesorter.isDigit(s, c);
         }, format: function (s) {
-            return $.tablesorter.formatFloat(s);
+            return $.tablesorter.formatFloat(s.replace(/,/g, ""));
         }, type: "numeric"
     });
 


### PR DESCRIPTION
The digit parser doesn't work with numbers formatted with a comma. Added regex to remove the comma for formatting.
