### PR TITLE
currency parser: thousands separator support

### DIFF
--- a/jquery.tablesorter.js
+++ b/jquery.tablesorter.js
@@ -900,7 +900,8 @@
         is: function (s, table) {
             var c = table.config;
             return $.tablesorter.isDigit(s, c);
-        }, format: function (s) {
+        }, format: function (s, table) {
+            s = s.replace(table.config.thousandsSeparator, '');
             return $.tablesorter.formatFloat(s);
         }, type: "numeric"
     });


### PR DESCRIPTION
When working with large figures in accounting applications, it's often preferred to format your numbers with grouped thousands through thousands separators. In example, presenting a large figure like $1386915 as $1,386,915 instead, makes it much more readable to the end-user.

Most server-side scripting languages and  spreadsheet applications provide all the necessary functionality for the purpose, in example:

http://php.net/manual/en/function.number-format.php
http://office.microsoft.com/en-001/excel-help/format-numbers-as-currency-HA102749029.aspx

...so many people rely on these functions in their everyday work to format and present their figures properly.

Unfortunately, Tablesorter doesn't provide native support to figures utilizing the aforementioned format, so if a user decides to present financial information formatted with thousands separators, Tablesorter identifies the data type as "currency", but is unable to sort it properly.

Therefore, I went ahead and added some minor modifications, so the currency parser can successfully sort figures, which make a use of thousands separators.

I have already used this functionality in a couple of projects and it works great. I hope it's useful to the community too.

All best,
Marin
