### PR TITLE
Ignore commas when sorting by currency

### DIFF
--- a/jquery.tablesorter.js
+++ b/jquery.tablesorter.js
@@ -909,7 +909,7 @@
         is: function (s) {
             return /^[£$€?.]/.test(s);
         }, format: function (s) {
-            return $.tablesorter.formatFloat(s.replace(new RegExp(/[£$€]/g), ""));
+            return $.tablesorter.formatFloat(s.replace(new RegExp(/[£$€,]/g), ""));
         }, type: "numeric"
     });
 


### PR DESCRIPTION
When sorting by currency, ignore commas for a proper sort. Fixes issue #43.
