### PR TITLE
Addition of 2 new options: sortChildren and sortInPlace

### DIFF
--- a/jquery.tablesorter.js
+++ b/jquery.tablesorter.js
@@ -120,6 +120,7 @@
                 sortAppend: null,
                 sortLocaleCompare: true,
                 sortChildren: false,
+                sortInPlace: false,
                 textExtraction: "simple",
                 parsers: {}, widgets: [],
                 widgetZebra: {
@@ -661,7 +662,10 @@
 
                 eval(dynamicExp);
 
-                cache.normalized.sort(sortWrapper);
+                // don't sort parent rows, if children rows are expanded and the "sort in place" setting is enabled
+                if (!table.config.sortInPlace || !$(table).find('.' + table.config.cssChildRow).is(':visible')) {
+                    cache.normalized.sort(sortWrapper);
+                }               
                 
                 if (table.config.sortChildren) {
                     var ncl = cache.normalizedChildren.length;


### PR DESCRIPTION
A few changes I had to implement for a project, in order to enable sorting of two-dimensional tables.

**sortChildren** - allows child rows to be sorted along with their parent
**sortInPlace** - allows visible children to be sorted, without changing the order of the parent rows. extremely useful, when you are trying to examine only the expanded child rows

**Demos available at:**
http://mbezhanov.github.io/tablesorter/example-sort-children.html
http://mbezhanov.github.io/tablesorter/example-sort-in-place.html

These demos are very similar to what we use in the project I made the changes for.
