### PR TITLE
Fix bug with tables that contains versions and implement parser for correct sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+/.project

--- a/jquery.tablesorter.js
+++ b/jquery.tablesorter.js
@@ -864,6 +864,17 @@
                 // replace all an wanted chars and match.
                 return /^[-+]?\d+$/.test($.trim(s.replace(/[.,]/, '').replace(/[']/g, '')));
             };
+            this.paddingInt = function (number, totalDigits) {
+                var digits = typeof totalDigits !== 'undefined' ? int(totalDigits) : 20;
+                var numStr = number.toString();
+                for (var i = numStr.length; i < digits; ++i) {
+                    numStr = '0' + numStr;
+                }
+                return numStr;
+            }
+            this.isVersion = function (s) {
+                return /^\d+(\.\d+)+([-_]\w+)?$/.test(s);
+            }
             this.clearTableBody = function (table) {
                 if ($.browser.msie) {
                     while (table.tBodies[0].firstChild) {
@@ -902,6 +913,24 @@
         }, format: function (s) {
             return $.tablesorter.formatFloat(s);
         }, type: "numeric"
+    });
+
+    ts.addParser({
+        id: "version",
+        is: function (s, table) {
+            return $.tablesorter.isVersion(s);
+        }, format: function (s) {
+            var res = "";
+            var segments = s.split(/[-_.]/);
+            for(var i = 0; i < segments.length; ++i) {
+                var value = segments[i];
+                if ($.tablesorter.isDigit(value)) {
+                    value = $.tablesorter.paddingInt(value);
+                }
+                res = res + '_' + value;
+            }
+            return res;
+        }, type: "text"
     });
 
     ts.addParser({

--- a/jquery.tablesorter.js
+++ b/jquery.tablesorter.js
@@ -862,7 +862,7 @@
             };
             this.isDigit = function (s, config) {
                 // replace all an wanted chars and match.
-                return /^[-+]?\d*$/.test($.trim(s.replace(/[,.']/g, '')));
+                return /^[-+]?\d+$/.test($.trim(s.replace(/[.,]/, '').replace(/[']/g, '')));
             };
             this.clearTableBody = function (table) {
                 if ($.browser.msie) {


### PR DESCRIPTION
Fix bug with tables that contains versions like "1.2.3", "1.2.4", "1.2.5" (first commit) and implement parser that helps correct sorting versions like "1.2.3", "1.2.4", "1.2.5", "1.11.3", "1.2.6-SNAPSHOT", "1.2.7_RC1", "1.2.7_RC2", "1.2.8-456" and etc (second commit).