### PR TITLE
Fix docs link to jQuery metadata

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -507,7 +507,7 @@ th.headerSortDown {
 		
 	<strong id="Download-Addons">Optional/Add-Ons:</strong>
 	<ul>
-		<li><a class="external" href="http://jquery.com/dev/svn/trunk/plugins/metadata/lib/jQuery/metadata.js?format=raw">metadata.js</a> (3,7kb <strong>Required for setting <a href="#Examples">inline options</a></strong>)</li>
+		<li><a class="external" href="https://raw.githubusercontent.com/jquery-archive/jquery-metadata/master/jquery.metadata.js">metadata.js</a> (3,7kb <strong>Required for setting <a href="#Examples">inline options</a></strong>)</li>
 		<!--
 		<li><a class="external" href="http://dev.jquery.com/browser/trunk/plugins/dimensions/jquery.dimensions.
 .js?format=raw">jquery.dimensions.pack.js</a> (5,1kb, <a href="http://dean.edwards.name/packer/" class="external">packed</a>, for production. <strong>Required: for the <a href="example-pager.html">tablesorter pagination plugin</a></strong>)</li>


### PR DESCRIPTION
Fixing documentation link to jQuery metadata, as the current one is invalid.