### PR TITLE
now allows numbers with comma separators

### DIFF
--- a/jquery.tablesorter.js
+++ b/jquery.tablesorter.js
@@ -903,6 +903,16 @@
             return $.tablesorter.formatFloat(s);
         }, type: "numeric"
     });
+    
+    ts.addParser({
+        id: "uiDigit",
+        is: function (s, table) {
+            var c = table.config;
+            return /[1-9](?:\d{0,2})(?:,\d{3})*(?:\.\d*[1-9])?|0?\.\d*[1-9]|0/.test(s);
+        }, format: function (s) {
+            return $.tablesorter.formatFloat(s);
+        }, type: "numeric"
+    });
 
     ts.addParser({
         id: "currency",


### PR DESCRIPTION
This allows sorting of columns that have numbers with commas. For example, with out this "346,782.25" was not sorting properly against numbers that didn't have commas. You would see things like:

346
458,278
789

This should fix that
