### PR TITLE
Allow usage of custom locales for sorting

### DIFF
--- a/jquery.tablesorter.js
+++ b/jquery.tablesorter.js
@@ -890,7 +890,7 @@
         is: function (s) {
             return true;
         }, format: function (s) {
-            return $.trim(s.toLocaleLowerCase());
+            return $.trim(s.toLocaleLowerCase().cleanAccents());
         }, type: "text"
     });
 
@@ -1036,3 +1036,31 @@
         }
     });
 })(jQuery);
+
+// Convert characters with accents to normal
+String.prototype.cleanAccents = function () {
+    var string = this;
+    var mapaAcentosHex = {
+        a: /[\xE0-\xE6]/g,
+        A: /[\xC0-\xC6]/g,
+        e: /[\xE8-\xEB]/g,
+        E: /[\xC8-\xCB]/g,
+        i: /[\xEC-\xEF]/g,
+        I: /[\xCC-\xCF]/g,
+        o: /[\xF2-\xF6]/g,
+        O: /[\xD2-\xD6]/g,
+        u: /[\xF9-\xFC]/g,
+        U: /[\xD9-\xDC]/g,
+        c: /\xE7/g,
+        C: /\xC7/g,
+        n: /\xF1/g,
+        N: /\xD1/g,
+    };
+
+    for (var letra in mapaAcentosHex) {
+        var expressaoRegular = mapaAcentosHex[letra];
+        string = string.replace(expressaoRegular, letra);
+    }
+
+    return string;
+}

--- a/jquery.tablesorter.js
+++ b/jquery.tablesorter.js
@@ -75,6 +75,9 @@
  * @option Boolean sortLocaleCompare (optional) Boolean flag indicating whatever
  *         to use String.localeCampare method or not. Default set to true.
  * 
+ * @option Array sortLocaleOverride (optional) This array overrides the locale(s)
+ *         that are used for sorting (only used if sortLocaleCompare is true). By
+ *         default the locale from the browser settings are used.
  * 
  * @option Array sortAppend (optional) An array containing forced sorting rules.
  *         This option let's you specify a default sorting rule, which is
@@ -119,6 +122,7 @@
                 sortForce: null,
                 sortAppend: null,
                 sortLocaleCompare: true,
+                sortLocaleOverride: [],
                 textExtraction: "simple",
                 parsers: {}, widgets: [],
                 widgetZebra: {
@@ -645,12 +649,12 @@
                     b = "b[" + index + "]";
                 if (type == 'text' && direction == 'asc') {
                     if (table.config.sortLocaleCompare)
-                        return "(" + a + " == " + b + " ? 0 : (" + a + " === null ? Number.POSITIVE_INFINITY : (" + b + " === null ? Number.NEGATIVE_INFINITY : " + a + ".localeCompare(" + b + "))));";
+                        return "(" + a + " == " + b + " ? 0 : (" + a + " === null ? Number.POSITIVE_INFINITY : (" + b + " === null ? Number.NEGATIVE_INFINITY : " + a + ".localeCompare(" + b + ", table.config.sortLocaleOverride))));";
                     else
                         return "(" + a + " == " + b + " ? 0 : (" + a + " === null ? Number.POSITIVE_INFINITY : (" + b + " === null ? Number.NEGATIVE_INFINITY : (" + a + " < " + b + ") ? -1 : 1 )));";
                 } else if (type == 'text' && direction == 'desc') {
                     if (table.config.sortLocaleCompare)
-                        return "(" + a + " == " + b + " ? 0 : (" + a + " === null ? Number.POSITIVE_INFINITY : (" + b + " === null ? Number.NEGATIVE_INFINITY : " + b + ".localeCompare(" + a + "))));";
+                        return "(" + a + " == " + b + " ? 0 : (" + a + " === null ? Number.POSITIVE_INFINITY : (" + b + " === null ? Number.NEGATIVE_INFINITY : " + b + ".localeCompare(" + a + ", table.config.sortLocaleOverride))));";
                     else
                         return "(" + a + " == " + b + " ? 0 : (" + a + " === null ? Number.POSITIVE_INFINITY : (" + b + " === null ? Number.NEGATIVE_INFINITY : (" + b + " < " + a + ") ? -1 : 1 )));";
                 } else if (type == 'numeric' && direction == 'asc') {
@@ -677,12 +681,12 @@
             };
 
             function sortText(a, b) {
-                if (table.config.sortLocaleCompare) return a.localeCompare(b);
+                if (table.config.sortLocaleCompare) return a.localeCompare(b, table.config.sortLocaleOverride);
                 return ((a < b) ? -1 : ((a > b) ? 1 : 0));
             };
 
             function sortTextDesc(a, b) {
-                if (table.config.sortLocaleCompare) return b.localeCompare(a);
+                if (table.config.sortLocaleCompare) return b.localeCompare(a, table.config.sortLocaleOverride);
                 return ((b < a) ? -1 : ((b > a) ? 1 : 0));
             };
 

--- a/jquery.tablesorter.js
+++ b/jquery.tablesorter.js
@@ -128,7 +128,8 @@
                 sortList: [],
                 headerList: [],
                 dateFormat: "us",
-                decimal: '/\.|\,/g',
+                decimal: '.',
+                thousandsSeparator: ',',
                 onRenderHeader: null,
                 selectorHeaders: 'thead th',
                 debug: false

--- a/jquery.tablesorter.js
+++ b/jquery.tablesorter.js
@@ -862,7 +862,8 @@
             };
             this.isDigit = function (s, config) {
                 // replace all an wanted chars and match.
-                return /^[-+]?\d*$/.test($.trim(s.replace(/[,.']/g, '')));
+                var regex = new RegExp('^[\\-\\+]?\\d*\\' + config.decimal + '?\\d*$', 'g');
+                return regex.test($.trim(s.replace(new RegExp('\\' + config.thousandsSeparator, 'g'), '')));
             };
             this.clearTableBody = function (table) {
                 if ($.browser.msie) {
@@ -899,17 +900,18 @@
         is: function (s, table) {
             var c = table.config;
             return $.tablesorter.isDigit(s, c);
-        }, format: function (s) {
-            return $.tablesorter.formatFloat(s);
+        }, format: function (s, table) {
+            return $.tablesorter.formatFloat(s.replace(new RegExp('\\' + table.config.thousandsSeparator, 'g'), '').replace(new RegExp('\\' + table.config.decimal, 'g'), '.'));
         }, type: "numeric"
     });
 
     ts.addParser({
         id: "currency",
-        is: function (s) {
-            return /^[£$€?.]/.test(s);
+        is: function (s, table) {
+            var c = table.config;
+            return /^\w?[£$€\?.]/.test(s) && $.tablesorter.isDigit(s.replace(new RegExp(/^\w?[£$€\?.]/g), ""), c);
         }, format: function (s) {
-            return $.tablesorter.formatFloat(s.replace(new RegExp(/[£$€]/g), ""));
+            return $.tablesorter.formatFloat(s.replace(new RegExp(/^\w?[£$€\?.]/g), "").replace(new RegExp('\\' + table.config.thousandsSeparator, 'g'), '').replace(new RegExp('\\' + table.config.decimal, 'g'), '.'));
         }, type: "numeric"
     });
 

--- a/jquery.tablesorter.js
+++ b/jquery.tablesorter.js
@@ -604,7 +604,7 @@
                     // var s = (table.config.parsers[c].type == "text") ? ((order == 0)
                     // ? makeSortText(c) : makeSortTextDesc(c)) : ((order == 0) ?
                     // makeSortNumeric(c) : makeSortNumericDesc(c));
-                    var s = (table.config.parsers[c].type == "text") ? ((order == 0) ? makeSortFunction("text", "asc", c) : makeSortFunction("text", "desc", c)) : ((order == 0) ? makeSortFunction("numeric", "asc", c) : makeSortFunction("numeric", "desc", c));
+                    var s = (table.config.parsers[c].type == "text") ? ((order == 0) ? makeSortFunction("text", "asc", c, table) : makeSortFunction("text", "desc", c, table)) : ((order == 0) ? makeSortFunction("numeric", "asc", c, table) : makeSortFunction("numeric", "desc", c, table));
                     var e = "e" + i;
 
                     dynamicExp += "var " + e + " = " + s; // + "(a[" + c + "],b[" + c
@@ -640,13 +640,19 @@
                 return cache;
             };
 
-            function makeSortFunction(type, direction, index) {
+            function makeSortFunction(type, direction, index, table) {
                 var a = "a[" + index + "]",
                     b = "b[" + index + "]";
                 if (type == 'text' && direction == 'asc') {
-                    return "(" + a + " == " + b + " ? 0 : (" + a + " === null ? Number.POSITIVE_INFINITY : (" + b + " === null ? Number.NEGATIVE_INFINITY : (" + a + " < " + b + ") ? -1 : 1 )));";
+                    if (table.config.sortLocaleCompare)
+                        return "(" + a + " == " + b + " ? 0 : (" + a + " === null ? Number.POSITIVE_INFINITY : (" + b + " === null ? Number.NEGATIVE_INFINITY : " + a + ".localeCompare(" + b + "))));";
+                    else
+                        return "(" + a + " == " + b + " ? 0 : (" + a + " === null ? Number.POSITIVE_INFINITY : (" + b + " === null ? Number.NEGATIVE_INFINITY : (" + a + " < " + b + ") ? -1 : 1 )));";
                 } else if (type == 'text' && direction == 'desc') {
-                    return "(" + a + " == " + b + " ? 0 : (" + a + " === null ? Number.POSITIVE_INFINITY : (" + b + " === null ? Number.NEGATIVE_INFINITY : (" + b + " < " + a + ") ? -1 : 1 )));";
+                    if (table.config.sortLocaleCompare)
+                        return "(" + a + " == " + b + " ? 0 : (" + a + " === null ? Number.POSITIVE_INFINITY : (" + b + " === null ? Number.NEGATIVE_INFINITY : " + b + ".localeCompare(" + a + "))));";
+                    else
+                        return "(" + a + " == " + b + " ? 0 : (" + a + " === null ? Number.POSITIVE_INFINITY : (" + b + " === null ? Number.NEGATIVE_INFINITY : (" + b + " < " + a + ") ? -1 : 1 )));";
                 } else if (type == 'numeric' && direction == 'asc') {
                     return "(" + a + " === null && " + b + " === null) ? 0 :(" + a + " === null ? Number.POSITIVE_INFINITY : (" + b + " === null ? Number.NEGATIVE_INFINITY : " + a + " - " + b + "));";
                 } else if (type == 'numeric' && direction == 'desc') {
@@ -892,7 +898,7 @@
         is: function (s) {
             return true;
         }, format: function (s) {
-            return $.trim(s.toLocaleLowerCase().cleanAccents());
+            return $.trim(s.toLocaleLowerCase());
         }, type: "text"
     });
 
@@ -1040,30 +1046,3 @@
     });
 })(jQuery);
 
-// Convert characters with accents to normal
-String.prototype.cleanAccents = function () {
-    var string = this;
-    var mapaAcentosHex = {
-        a: /[\xE0-\xE6]/g,
-        A: /[\xC0-\xC6]/g,
-        e: /[\xE8-\xEB]/g,
-        E: /[\xC8-\xCB]/g,
-        i: /[\xEC-\xEF]/g,
-        I: /[\xCC-\xCF]/g,
-        o: /[\xF2-\xF6]/g,
-        O: /[\xD2-\xD6]/g,
-        u: /[\xF9-\xFC]/g,
-        U: /[\xD9-\xDC]/g,
-        c: /\xE7/g,
-        C: /\xC7/g,
-        n: /\xF1/g,
-        N: /\xD1/g,
-    };
-
-    for (var letra in mapaAcentosHex) {
-        var expressaoRegular = mapaAcentosHex[letra];
-        string = string.replace(expressaoRegular, letra);
-    }
-
-    return string;
-}


### PR DESCRIPTION
A new setting "sortLocaleOverride" is introduced that allows
passing an array of locales that should be used for sorting.

This patch is based on pull request #56
