### PR TITLE
[BUGFIX] Fix detection of short dates

### DIFF
--- a/jquery.tablesorter.js
+++ b/jquery.tablesorter.js
@@ -973,7 +973,7 @@
     ts.addParser({
         id: "shortDate",
         is: function (s) {
-            return /\d{1,2}[\/\-]\d{1,2}[\/\-]\d{2,4}/.test(s);
+            return /^\d{1,2}[\/\-]\d{1,2}[\/\-]\d{2,4}$/.test(s);
         }, format: function (s, table) {
             var c = table.config;
             s = s.replace(/\-/g, "/");


### PR DESCRIPTION
Only columns that contain a short date an nothing else will be
treated as short dates. This makes sure that texts containing
a short date somewhere will not be treated as a date.
