### PR TITLE
initial click on a header uses sortInitialOrder

### DIFF
--- a/jquery.tablesorter.js
+++ b/jquery.tablesorter.js
@@ -733,7 +733,10 @@
                             this.order = this.count++ % 2;
 							// always sort on the locked order.
 							if(this.lockedOrder) this.order = this.lockedOrder;
-							
+							// set every other header back to the default initial sort order
+                            $headers.not($cell).each( function() {
+								this.count = formatSortingOrder(config.sortInitialOrder);
+							});							
 							// user only whants to sort on one
                             // column
                             if (!e[config.sortMultiSortKey]) {


### PR DESCRIPTION
Behavior before this change:

1) click header_X, table is resorted by header_X_col in sortInitialOrder
2) click header_Y, table is resorted by header_Y_col in sortInitialOrder
3) click header_X again, table is resorted by header_X_col in opposite of sortInitialOrder
4) click header_Y again, table is resorted by header_Y_col in opposite of sortInitialOrder

Behavior after this change:

1) click header_X, table is resorted by header_X_col in sortInitialOrder
2) click header_Y, table is resorted by header_Y_col in sortInitialOrder
3) click header_X again, table is resorted by header_X_col in sortInitialOrder
3) click header_Y again, table is resorted by header_Y_col in sortInitialOrder