### PR TITLE
Update parser.format arguments to match buildCache

### DIFF
--- a/jquery.tablesorter.js
+++ b/jquery.tablesorter.js
@@ -806,7 +806,7 @@
                         var pos = [(cell.parentNode.rowIndex - 1), cell.cellIndex];
                         // update cache
                         cache.normalized[pos[0]][pos[1]] = config.parsers[pos[1]].format(
-                        getElementText(config, cell), cell);
+                        getElementText(config, cell), table, cell);
                     }).bind("sorton", function (e, list) {
                         $(this).trigger("sortStart");
                         config.sortList = list;


### PR DESCRIPTION
`buildCache` (~ln 279) uses the arguments `text, table, cell` which this patch changes the update call to use
