### PR TITLE
Fix documentation for a few options

### DIFF
--- a/jquery.tablesorter.js
+++ b/jquery.tablesorter.js
@@ -60,17 +60,25 @@
  *         option to "complex", on large tables the complex option can be slow.
  *         Default value: "simple"
  * 
- * @option Object headers (optional) An array containing the forces sorting
- *         rules. This option let's you specify a default sorting rule. Default
- *         value: null
+ * @option Object headers (optional) An object of instructions for per-column
+ *         controls in the format: headers: { 0: { option: setting }, ... }. For 
+ *         example, to disable sorting on the first two columns of a table:
+ *         headers: { 0: { sorter: false}, 1: {sorter: false} }.
+ *         Default value: null.
  * 
- * @option Array sortList (optional) An array containing the forces sorting
- *         rules. This option let's you specify a default sorting rule. Default
- *         value: null
+ * @option Array sortList (optional) An array of instructions for per-column sorting 
+ *         and direction in the format: [[columnIndex, sortDirection], ... ] where 
+ *         columnIndex is a zero-based index for your columns left-to-right and 
+ *         sortDirection is 0 for Ascending and 1 for Descending. A valid argument 
+ *         that sorts ascending first by column 1 and then column 2 looks like: 
+ *         [[0,0],[1,0]]. Default value: null.
  * 
  * @option Array sortForce (optional) An array containing forced sorting rules.
- *         This option let's you specify a default sorting rule, which is
- *         prepended to user-selected rules. Default value: null
+ *         Use to add an additional forced sort that will be appended to the dynamic
+ *         selections by the user. For example, can be used to sort people alphabetically
+ *         after some other user-selected sort that results in rows with the same value 
+ *         like dates or money due. It can help prevent data from appearing as though it 
+ *         has a random secondary sort. Default value: null.
  * 
  * @option Boolean sortLocaleCompare (optional) Boolean flag indicating whatever
  *         to use String.localeCampare method or not. Default set to true.


### PR DESCRIPTION
It looks like `headers`, `sortList` and `sortForce` had the same documentation, a boilertplate entry for `sortList`. Replace these with the documentation present on http://tablesorter.com/docs/, which is much more detailed.
