### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 tablesorter
 ===========
 
-###Flexible client-side table sorting
-####Getting started
+### Flexible client-side table sorting
+#### Getting started
 
 To use the tablesorter plugin, include the jQuery library and the tablesorter plugin inside the head-tag of your HTML document:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
